### PR TITLE
Fix multiple DispatchGroup leaves

### DIFF
--- a/push/CHANGELOG.md
+++ b/push/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.5
+
+- fix: `leave` token `DispatchGroup` more times than there are `enter`s
+
 ## 0.0.4
 
 - docs: fix broken links in documentation

--- a/push/pubspec.yaml
+++ b/push/pubspec.yaml
@@ -1,6 +1,6 @@
 name: push
 description: Push notifications in Flutter without firebase_messaging.
-version: 0.0.4
+version: 0.0.5
 repository: https://github.com/ben-xD/push
 issue_tracker: https://github.com/ben-xD/push/issues?q=is%3Aissue+is%3Aopen
 homepage: https://orth.uk/

--- a/push_ios/ios/Classes/PushHostHandlers.swift
+++ b/push_ios/ios/Classes/PushHostHandlers.swift
@@ -170,6 +170,9 @@ class PushHostHandlers: NSObject, PUPushHostApi {
     }
         
     private func enterDeviceTokenReadyDispatchGroup(){
+        if(deviceTokenReadyDispatchGroupEnters < 0){
+            deviceTokenReadyDispatchGroupEnters = 0
+        }
         deviceTokenReadyDispatchGroupEnters += 1;
         deviceTokenReadyDispatchGroup.enter()
     }
@@ -177,7 +180,7 @@ class PushHostHandlers: NSObject, PUPushHostApi {
     private func leaveDeviceTokenReadyDispatchGroup(){
         deviceTokenReadyDispatchGroupEnters -= 1;
         if(deviceTokenReadyDispatchGroupEnters >= 0){
-            deviceTokenReadyDispatchGroup.leave();
+            deviceTokenReadyDispatchGroup.leave()
         }
     }
 }


### PR DESCRIPTION
## Issue

It appears that if you use multiple packages that hook into push notifications, some might trigger `didRegisterForRemoteNotificationsWithDeviceToken` multiple times (in my case, twice).

Because you can only leave a `DispatchGroup` as many times as you enter it, `deviceTokenReadyDispatchGroup.leave()` throws an error. This crashes the app.

## Solution
Track how many times the `DispatchGroup` was entered, so extra leaves are ignored.