### PR TITLE
Fix initial notification on tap handling

### DIFF
--- a/push_ios/ios/Classes/UserNotificationCenterDelegateHandlers.swift
+++ b/push_ios/ios/Classes/UserNotificationCenterDelegateHandlers.swift
@@ -10,14 +10,14 @@ class UserNotificationCenterDelegateHandlers: NSObject, UNUserNotificationCenter
         super.init()
     }
 
-    func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UserNotifications.UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> ()) {
+    func userNotificationCenter(_: UNUserNotificationCenter, willPresent notification: UserNotifications.UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
         // When a foreground notification is delivered and the user schedules a local notification, this is called twice.
         // - First, when the notification is received from APNs directly. To be consistent with Android behaviour, we ignore it. In this case, notification.request.trigger is a `UNPushNotificationTrigger`
         // - When received from flutter_local_notifications, I want to display it. In this case, notification.request.trigger is nil.
-        if (notification.request.trigger is UNPushNotificationTrigger) {
+        if notification.request.trigger is UNPushNotificationTrigger {
             let message = PURemoteMessage.from(userInfo: notification.request.content.userInfo)
-                pushFlutterApi.onMessageMessage(message) { _ in
-             }
+            pushFlutterApi.onMessageMessage(message) { _ in
+            }
             // Do not display the notification received from APNs
             completionHandler([])
         } else {
@@ -30,20 +30,13 @@ class UserNotificationCenterDelegateHandlers: NSObject, UNUserNotificationCenter
         }
     }
 
-    private var userTapsOnNotificationCount = 0;
-    
-    func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> ()) {
-        // Avoid sending the message that launched the app. We will send that one when the user requests for the "Push.instance.notificationTapWhichLaunchedAppFromTerminated" (Dart code)
-        if (userTapsOnNotificationCount > 0) {
-//            let message = PURemoteMessage.fromNotificationContent(content: response.notification.request.content)
-            pushFlutterApi.onNotificationTapData(response.notification.request.content.userInfo as! [String: Any]) { _ in  }
-        }
+    func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
+        pushFlutterApi.onNotificationTapData(response.notification.request.content.userInfo as! [String: Any]) { _ in }
         callOriginalDidReceiveDelegateMethod(center: center, response: response, completionHandler: completionHandler)
-        userTapsOnNotificationCount += 1
     }
 
     // Allow users original UNUserNotificationCenterDelegate they set to respond.
-    private func callOriginalDidReceiveDelegateMethod(center: UNUserNotificationCenter, response: UNNotificationResponse, completionHandler: @escaping () -> ()) { // `as` is used because userNotificationCenter on its own is ambiguous (userNotificationCenter corresponds to 3 methods).
+    private func callOriginalDidReceiveDelegateMethod(center: UNUserNotificationCenter, response: UNNotificationResponse, completionHandler: @escaping () -> Void) { // `as` is used because userNotificationCenter on its own is ambiguous (userNotificationCenter corresponds to 3 methods).
         // See https://stackoverflow.com/questions/35658334/how-do-i-resolve-ambiguous-use-of-compile-error-with-swift-selector-syntax
         let didReceiveDelegateMethodSelector = #selector(userNotificationCenter as (UNUserNotificationCenter, UNNotificationResponse, @escaping () -> Void) -> Void)
         if let originalDelegate = originalDelegate, originalDelegate.responds(to: didReceiveDelegateMethodSelector) {


### PR DESCRIPTION
This pull request addresses an issue in the application's notification handling process. Currently, the `onNotificationTapData` method is not being called on the first tap of a notification but instead is only invoked from the second tap. As reported in #16.

It appears that there is a leftover `userTapsOnNotificationCount` variable. This variable is only incremented after the `userNotificationCenter:didReceive` delegate is called. 

The existing comments imply that it is to handle a behavior related to launch app by a notification, but this has already been handled in `application:didFinishLaunchingWithOptions` delegate. 
