### PR TITLE
fix(android): fix PushApi.RemoteMessage notification attribute serial…

### DIFF
--- a/push_android/android/src/main/java/uk/orth/push/serialization/Serialization.kt
+++ b/push_android/android/src/main/java/uk/orth/push/serialization/Serialization.kt
@@ -4,20 +4,30 @@ import com.google.firebase.messaging.RemoteMessage
 
 fun RemoteMessage.toMap(): Map<String, Any?> {
     return mapOf<String, Any?>(
-        "data" to data,
-        "notification" to notification?.toMap()
+            "data" to data,
+            "notification" to notification?.toMap()
     )
 }
 
 fun RemoteMessage.Notification.toMap(): Map<String, Any?> {
     return mapOf(
-        "title" to this.title,
-        "body" to this.body
+            "title" to this.title,
+            "body" to this.body
     )
+}
+
+fun RemoteMessage.Notification.toPushNotification(): PushApi.Notification {
+    this.let {
+        val pushNotification = PushApi.Notification()
+        pushNotification.title = it.title
+        pushNotification.body = it.body
+        return pushNotification
+    }
 }
 
 fun RemoteMessage.toPushRemoteMessage(): PushApi.RemoteMessage {
     val message = PushApi.RemoteMessage()
-    message.data = this.toMap()
+    message.data = this.data.toMap()
+    message.notification = this.notification?.toPushNotification()
     return message
 }


### PR DESCRIPTION
This pull request aims to resolve an issue related to notification payload parsing on Android devices. As per the current behavior, the `RemoteMessage.Notification` object is returned as null, which is not the expected outcome. Upon inspection, it was found that the notification payload is being incorrectly wrapped within the `RemoteMessage.Data` object, instead of being directly accessible via the `RemoteMessage.Notification` object.

Closes #15 
