### PR TITLE
fix(ios): don't show duplicate first tapped notification

### DIFF
--- a/push_ios/ios/Classes/UserNotificationCenterDelegateHandlers.swift
+++ b/push_ios/ios/Classes/UserNotificationCenterDelegateHandlers.swift
@@ -30,8 +30,16 @@ class UserNotificationCenterDelegateHandlers: NSObject, UNUserNotificationCenter
         }
     }
 
+    private var userTappedOnNotificationCount = 0;
     func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
-        pushFlutterApi.onNotificationTapData(response.notification.request.content.userInfo as! [String: Any]) { _ in }
+        // Prevents sending notification to users twice when their app is launched by a tap.
+        // We will send that one when the user requests for the "Push.instance.notificationTapWhichLaunchedAppFromTerminated" (Dart code)
+        let skip = userTappedOnNotificationCount == 0 && PushHostHandlers.notificationTapWhichLaunchedAppUserInfo != nil
+        if (!skip) {
+            pushFlutterApi.onNotificationTapData(response.notification.request.content.userInfo as! [String: Any]) { _ in }
+        }
+
+        userTappedOnNotificationCount += 1;
         callOriginalDidReceiveDelegateMethod(center: center, response: response, completionHandler: completionHandler)
     }
 


### PR DESCRIPTION
The first tapped notification (that started app) was duplicated in `onNotificationTap` and `notificationTapWhichLaunchedAppFromTerminated`

@kaiquegazola, looks like that code removed in https://github.com/ben-xD/push/pull/19 was there for a reason, but it was buggy so this should fix it.

Closes https://github.com/ben-xD/push/issues/24