### PR TITLE
fix(example/android): include notification data on notification tap when app in foreground

### DIFF
--- a/push/README.md
+++ b/push/README.md
@@ -255,7 +255,7 @@ understand the difference between them though.
 On Android, notification taps are only sent back to you when your RemoteMessage contains data.
 Therefore, you cannot test this by sending a message from the Firebase notification composer. This
 is because the RemoteMessage in the intent extras which is passed simply does not include the
-notification .
+notification.
 
 ## Checklist
 


### PR DESCRIPTION
This is limited to example app, since it was not including the data when creating a local notification with Flutter Local Notifications package.