### PR TITLE
feat: replace stream API with callback API

### DIFF
--- a/push/CHANGELOG.md
+++ b/push/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0-dev.1
+
+- Replace streams API with callbacks
+
 ## 1.1.0
 
 - Update pigeon to 15.0.2

--- a/push/CHANGELOG.md
+++ b/push/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0
+
+- Replace streams API with callbacks
+
 ## 2.0.0-dev.1
 
 - Replace streams API with callbacks

--- a/push/README.md
+++ b/push/README.md
@@ -5,6 +5,10 @@
 - Look at the [features](#features) if you want to see if `push` will provide it.
 - Look at [comparisons](#comparisons) if you want to compare `Push` with other push notification packages for Flutter.
 
+## Updating to v2
+
+There are some breaking changes in version 2.0.0. Please see the [breaking changes](./UPDATING.md) for how to update your application.
+
 ## Features
 
 - Use push notification without Firebase on any platform except Android.

--- a/push/README.md
+++ b/push/README.md
@@ -188,7 +188,7 @@ and
       });
 
       // Handle push notifications
-      Push.instance.onMessage.listen((message) {
+      Push.instance.addOnMessage((message) {
         print('RemoteMessage received while app is in foreground:\n'
             'RemoteMessage.Notification: ${message.notification} \n'
             ' title: ${message.notification?.title.toString()}\n'
@@ -198,7 +198,7 @@ and
       });
 
       // Handle push notifications
-      Push.instance.onBackgroundMessage.listen((message) {
+      Push.instance.addOnBackgroundMessage((message) {
         print('RemoteMessage received while app is in background:\n'
             'RemoteMessage.Notification: ${message.notification} \n'
             ' title: ${message.notification?.title.toString()}\n'

--- a/push/UPDATING.md
+++ b/push/UPDATING.md
@@ -1,0 +1,23 @@
+# Breaking changes in v2
+
+This is a reference guide to the breaking changes introduced in v2, and how to migrate from v1.
+
+## Callback API
+
+The stream API has been replaced with a Callback API.
+
+### Previously
+```dart
+Push.instance.onMessage.listen((message) { /* do something with message */ });
+Push.instance.onBackgroundMessage.listen((message) { /* do something with message */ });
+```
+
+### Now
+```dart
+final unsubscribeOnMessage = Push.instance.addOnMessage((message) { /* do something with message */ });
+final unsubscribeOnBackgroundMessage = Push.instance.addOnBackgroundMessage((message) { /* do something with message */ });
+
+// Unsubscribe when it makes sense
+unsubscribeOnMessage();
+unsubscribeOnBackgroundMessage();
+```

--- a/push/example/lib/main.dart
+++ b/push/example/lib/main.dart
@@ -80,7 +80,7 @@ class MyApp extends HookWidget {
       });
 
       // Handle push notifications
-      final onMessageSubscription = Push.instance.onMessage.listen((message) {
+      final unsubscribeOnMessage = Push.instance.addOnMessage((message) {
         print('RemoteMessage received while app is in foreground:\n'
             'RemoteMessage.Notification: ${message.notification} \n'
             ' title: ${message.notification?.title.toString()}\n'
@@ -96,8 +96,8 @@ class MyApp extends HookWidget {
       });
 
       // Handle push notifications
-      final onBackgroundMessageSubscription =
-          Push.instance.onBackgroundMessage.listen((message) {
+      final unsubscribeOnBackgroundMessage =
+          Push.instance.addOnBackgroundMessage((message) {
         print('RemoteMessage received while app is in background:\n'
             'RemoteMessage.Notification: ${message.notification} \n'
             ' title: ${message.notification?.title.toString()}\n'
@@ -109,8 +109,8 @@ class MyApp extends HookWidget {
       return () {
         onNewTokenSubscription.cancel();
         onNotificationTapSubscription.cancel();
-        onMessageSubscription.cancel();
-        onBackgroundMessageSubscription.cancel();
+        unsubscribeOnMessage();
+        unsubscribeOnBackgroundMessage();
       };
     }, []);
 

--- a/push/example/lib/main.dart
+++ b/push/example/lib/main.dart
@@ -161,11 +161,27 @@ class MyApp extends HookWidget {
                   children: [
                     Text('Messages',
                         style: Theme.of(context).textTheme.headlineMedium),
-                    Text('Recent foreground notification',
-                        style: Theme.of(context).textTheme.headlineSmall),
+                    Row(children: [
+                      Text('Recent foreground notification',
+                          style: Theme.of(context).textTheme.headlineSmall),
+                      IconButton(
+                          onPressed: () {
+                            messagesReceived.value = [];
+                          },
+                          icon: const Icon(Icons.delete))
+                    ]),
                     RemoteMessagesWidget(messagesReceived.value),
-                    Text('Recent background notification',
-                        style: Theme.of(context).textTheme.headlineSmall),
+                    Row(
+                      children: [
+                        Text('Recent background notification',
+                            style: Theme.of(context).textTheme.headlineSmall),
+                        IconButton(
+                            onPressed: () {
+                              backgroundMessagesReceived.value = [];
+                            },
+                            icon: const Icon(Icons.delete))
+                      ],
+                    ),
                     RemoteMessagesWidget(backgroundMessagesReceived.value),
                   ],
                 ),
@@ -195,8 +211,20 @@ class MyApp extends HookWidget {
                     Text((notificationWhichLaunchedApp.value != null)
                         ? notificationWhichLaunchedApp.value.toString()
                         : "The app was not launched by an app pressing the notification."),
-                    Text('All notifications tapped since app launch',
-                        style: Theme.of(context).textTheme.headlineSmall),
+                    Row(
+                      children: [
+                        Flexible(
+                          child: Text(
+                              'All notifications tapped since app launch',
+                              style: Theme.of(context).textTheme.headlineSmall),
+                        ),
+                        IconButton(
+                            onPressed: () {
+                              tappedNotificationPayloads.value = [];
+                            },
+                            icon: const Icon(Icons.delete))
+                      ],
+                    ),
                     buildTappedNotificationsSliver(
                         context, tappedNotificationPayloads.value),
                   ],

--- a/push/example/pubspec.lock
+++ b/push/example/pubspec.lock
@@ -302,7 +302,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.1.0"
+    version: "2.0.0-dev.1"
   push_android:
     dependency: transitive
     description:

--- a/push/pubspec.lock
+++ b/push/pubspec.lock
@@ -127,18 +127,18 @@ packages:
     dependency: "direct main"
     description:
       name: push_android
-      sha256: "26252e53ce231423432e786ceff512645fd1252d3c495fc03dbb4c48bdc7a052"
+      sha256: "72e0953fdd94ae1e6fdf729b19eb8dfeea6d0b6f4c2d00551dbb4b6614444d4d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.3.0"
   push_ios:
     dependency: "direct main"
     description:
       name: push_ios
-      sha256: "57d37aec2345fea39e148b05f542104abb0389a7f301b5d0b1220fb30c62443e"
+      sha256: "10fef746f8f0fbc7150b70f0dc3d72fe57097ce206ed40549f161226bd3aaa1b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.3.0"
   push_macos:
     dependency: "direct main"
     description:
@@ -151,10 +151,10 @@ packages:
     dependency: "direct main"
     description:
       name: push_platform_interface
-      sha256: ae21472c621ea07c8078f60aa24c7264bbfd959ef6f5e391a5a46e07d87722e8
+      sha256: b1e9d99da7385502fb6e0241f3e5e0ec40ae9487faf8c6227730c59fc7bc81a4
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "0.4.0"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/push/pubspec.yaml
+++ b/push/pubspec.yaml
@@ -1,6 +1,6 @@
 name: push
 description: Push notifications in Flutter without firebase_messaging.
-version: 1.1.0
+version: 2.0.0-dev.1
 repository: https://github.com/ben-xD/push
 issue_tracker: https://github.com/ben-xD/push/issues?q=is%3Aissue+is%3Aopen
 homepage: https://orth.uk/
@@ -14,9 +14,9 @@ dependencies:
     sdk: flutter
 
   # Federated package dependencies
-  push_platform_interface: ^0.3.0
-  push_android: ^0.2.0
-  push_ios: ^0.2.0
+  push_platform_interface: ^0.4.0
+  push_android: ^0.3.0
+  push_ios: ^0.3.0
   push_macos: ^0.0.1
   # End of federated package dependencies
 

--- a/push_android/CHANGELOG.md
+++ b/push_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.0
+
+- Replace streams API with callbacks
+
 ## 0.2.0
 
 - Update pigeon to 15.0.2

--- a/push_android/android/src/main/kotlin/uk/orth/push/PushHostHandlers.kt
+++ b/push_android/android/src/main/kotlin/uk/orth/push/PushHostHandlers.kt
@@ -211,14 +211,27 @@ class PushHostHandlers(
             when (val action = intent.action) {
                 ON_MESSAGE_RECEIVED -> {
                     val message = RemoteMessage(intent.extras!!).toPushRemoteMessage()
-                    pushFlutterApi.onMessage(message, noOpNullableResult)
+                    pushFlutterApi.onMessage(message, object : PushApi.NullableResult<Void> {
+                        override fun success(result: Void?) {
+                            finish(context)
+                        }
+                        override fun error(error: Throwable) {
+                            finish(context)
+                        }
+                    })
                     finish(context)
                 }
 
                 ON_BACKGROUND_MESSAGE_RECEIVED -> {
                     val message = RemoteMessage(intent.extras!!).toPushRemoteMessage()
-                    pushFlutterApi.onBackgroundMessage(message, noOpNullableResult)
-                    finish(context)
+                    pushFlutterApi.onBackgroundMessage(message, object : PushApi.NullableResult<Void> {
+                        override fun success(result: Void?) {
+                            finish(context)
+                        }
+                        override fun error(error: Throwable) {
+                            finish(context)
+                        }
+                    })
                 }
 
                 ON_NEW_TOKEN -> {

--- a/push_android/pubspec.lock
+++ b/push_android/pubspec.lock
@@ -119,10 +119,10 @@ packages:
     dependency: "direct main"
     description:
       name: push_platform_interface
-      sha256: ae21472c621ea07c8078f60aa24c7264bbfd959ef6f5e391a5a46e07d87722e8
+      sha256: b1e9d99da7385502fb6e0241f3e5e0ec40ae9487faf8c6227730c59fc7bc81a4
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "0.4.0"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/push_android/pubspec.yaml
+++ b/push_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: push_android
 description: Push notifications in Flutter without firebase_messaging.
-version: 0.2.0
+version: 0.3.0
 repository: https://github.com/ben-xD/push
 issue_tracker: https://github.com/ben-xD/push/issues?q=is%3Aissue+is%3Aopen
 homepage: https://orth.uk/
@@ -14,7 +14,7 @@ dependencies:
     sdk: flutter
 
   # Federated package dependencies
-  push_platform_interface: ^0.3.0
+  push_platform_interface: ^0.4.0
 
   # Local development dependencies
   # push_platform_interface:

--- a/push_ios/CHANGELOG.md
+++ b/push_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.0
+
+- Replace streams API with callbacks
+
 ## 0.2.0
 
 - Update pigeon to 15.0.2

--- a/push_ios/ios/Classes/PushHostHandlers.swift
+++ b/push_ios/ios/Classes/PushHostHandlers.swift
@@ -127,17 +127,22 @@ class PushHostHandlers: NSObject, PUPushHostApi {
         // App in background or terminated
         let message = PURemoteMessage.from(userInfo: userInfo)
         if application.applicationState == .background || application.applicationState == .inactive {
-            pushFlutterApi.onBackgroundMessageMessage(message) { _ in }
+            pushFlutterApi.onBackgroundMessageMessage(message) { _ in 
+                completionHandler(.newData)
+            }
         } else { // App in foreground
             let aps = userInfo["aps"] as? [String: Any]
             let isAlertMessage = aps?["alert"] != nil
             // if "alert" APNs message, it is already sent in UserNotificationCenterDelegateHandlers userNotificationCenter_willPresent
             if !isAlertMessage {
                 // If "background" APNs message (it doesn't contain alert), we need to send it to onMessage.
-                pushFlutterApi.onMessageMessage(message) { _ in }
+                pushFlutterApi.onMessageMessage(message) { _ in 
+                    completionHandler(.newData)
+                }
+            } else {
+                completionHandler(.newData)
             }
         }
-        completionHandler(.newData)
         return true
     }
 

--- a/push_ios/pubspec.lock
+++ b/push_ios/pubspec.lock
@@ -119,10 +119,10 @@ packages:
     dependency: "direct main"
     description:
       name: push_platform_interface
-      sha256: ae21472c621ea07c8078f60aa24c7264bbfd959ef6f5e391a5a46e07d87722e8
+      sha256: b1e9d99da7385502fb6e0241f3e5e0ec40ae9487faf8c6227730c59fc7bc81a4
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "0.4.0"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/push_ios/pubspec.yaml
+++ b/push_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: push_ios
 description: Push notifications in Flutter without firebase_messaging.
-version: 0.2.0
+version: 0.3.0
 repository: https://github.com/ben-xD/push
 issue_tracker: https://github.com/ben-xD/push/issues?q=is%3Aissue+is%3Aopen
 homepage: https://orth.uk/
@@ -14,7 +14,7 @@ dependencies:
     sdk: flutter
 
   # Federated package dependencies
-  push_platform_interface: ^0.3.0
+  push_platform_interface: ^0.4.0
 
   # Local development dependencies
   # push_platform_interface:

--- a/push_macos/pubspec.yaml
+++ b/push_macos/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  push_platform_interface: ^0.3.0
+  push_platform_interface: ^0.4.0
 
   # Local development dependencies
 #  push_platform_interface:

--- a/push_platform_interface/CHANGELOG.md
+++ b/push_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.0
+
+- Replace streams API with callbacks
+
 ## 0.3.0
 
 - Update pigeon to 15.0.2

--- a/push_platform_interface/lib/src/serialization/push_api.dart
+++ b/push_platform_interface/lib/src/serialization/push_api.dart
@@ -540,9 +540,9 @@ abstract class PushFlutterApi {
   static const MessageCodec<Object?> pigeonChannelCodec =
       _PushFlutterApiCodec();
 
-  void onMessage(RemoteMessage message);
+  Future<void> onMessage(RemoteMessage message);
 
-  void onBackgroundMessage(RemoteMessage message);
+  Future<void> onBackgroundMessage(RemoteMessage message);
 
   /// Unfortunately, the intent provided to the app when a user taps on a
   /// notification does not include notification's title or body.
@@ -576,7 +576,7 @@ abstract class PushFlutterApi {
           assert(arg_message != null,
               'Argument for dev.flutter.pigeon.push_platform_interface.PushFlutterApi.onMessage was null, expected non-null RemoteMessage.');
           try {
-            api.onMessage(arg_message!);
+            await api.onMessage(arg_message!);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
@@ -604,7 +604,7 @@ abstract class PushFlutterApi {
           assert(arg_message != null,
               'Argument for dev.flutter.pigeon.push_platform_interface.PushFlutterApi.onBackgroundMessage was null, expected non-null RemoteMessage.');
           try {
-            api.onBackgroundMessage(arg_message!);
+            await api.onBackgroundMessage(arg_message!);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);

--- a/push_platform_interface/pigeons/push_api.dart
+++ b/push_platform_interface/pigeons/push_api.dart
@@ -67,8 +67,10 @@ abstract class PushHostApi {
 
 @FlutterApi()
 abstract class PushFlutterApi {
+  @async
   void onMessage(RemoteMessage message);
 
+  @async
   void onBackgroundMessage(RemoteMessage message);
 
   /// Unfortunately, the intent provided to the app when a user taps on a

--- a/push_platform_interface/pubspec.yaml
+++ b/push_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: Push notifications in Flutter without firebase_messaging.
 
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 0.3.0
+version: 0.4.0
 repository: https://github.com/ben-xD/push
 issue_tracker: https://github.com/ben-xD/push/issues?q=is%3Aissue+is%3Aopen
 homepage: https://orth.uk/


### PR DESCRIPTION
This allows us to await handlers to avoid shutting app down too early. This also allows us to have multiple listeners for the same event (message, background message)

There is a dev release you can try: **2.0.0-dev.1**. This would be released as `2.0.0` on 31st December

The API has been changed (see [migration guide](https://github.com/ben-xD/push/blob/48f862f6030fc96619f6dd22c795911b7da51279/push/UPDATING.md#L23)), and now looks like:
https://github.com/ben-xD/push/blob/49a4a1e5978a65b023a7b005559f21f9633a906f/push/example/lib/main.dart#L82-L107